### PR TITLE
Automatic baud detection

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,7 +8,8 @@
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/plerup/espsoftwareserial"
+        "url": "https://github.com/ratgdo/espsoftwareserial",
+	"branch": "autobaud"
     },
     "authors": [
         {

--- a/src/SoftwareSerial.h
+++ b/src/SoftwareSerial.h
@@ -187,6 +187,8 @@ public:
     void setTransmitEnablePin(int8_t txEnablePin);
     /// Enable (default) or disable interrupts during tx.
     void enableIntTx(bool on);
+    /// Enable baud rate estimation based on frame separator
+    void enableAutoBaud(bool on, uint8_t sep = 0x55);
     /// Enable (default) or disable internal rx GPIO pull-up.
     void enableRxGPIOPullUp(bool on);
     /// Enable or disable (default) tx GPIO output mode.
@@ -349,7 +351,12 @@ private:
     uint8_t m_stopBits;
     bool m_lastReadParity;
     bool m_overflow = false;
+    bool m_autoBaud = false;
+    bool m_autoBaudEnabled = false;
+    uint8_t m_frameSep;
+    uint32_t m_rxByteTicks;
     uint32_t m_bitTicks;
+    uint32_t m_origBitTicks;
     uint8_t m_parityInPos;
     uint8_t m_parityOutPos;
     int8_t m_rxLastBit; // 0 thru (m_pduBits - m_stopBits - 1): data/parity bits. -1: start bit. (m_pduBits - 1): stop bit.


### PR DESCRIPTION
This implements automatic baud detection based on a separator/header byte (`0x55` typically, because it's easiest to correctly decode with a slightly mismatched baud rate - `01010101` in binary). 

It assumes a gap between message packets of at least (`m_pduBits+1` - start, data and stop bits) to reset to the baseline baud rate for the next baud detection.